### PR TITLE
add #include <functional>

### DIFF
--- a/src/qib.h
+++ b/src/qib.h
@@ -7,6 +7,7 @@
 #include "Order.h"
 #include "Execution.h"
 #include "ScannerSubscription.h"
+#include <functional>
 
 extern "C"
 {


### PR DESCRIPTION
prevents following errors during compilation:

```
/home/dk/qib/src/qib.cpp:658:52: note: ‘std::function’ is defined in header ‘<functional>’; did you forget to ‘#include <functional>’?
/home/dk/qib/src/qib.cpp:658:52: error: ‘function’ is not a member of ‘std’
/home/dk/qib/src/qib.cpp:658:52: note: ‘std::function’ is defined in header ‘<functional>’; did you forget to ‘#include <functional>’?
/home/dk/qib/src/qib.cpp:658:89: error: expression list treated as compound expression in functional cast [-fpermissive]
V setProperties(K dict, std::map<std::string, std::function<V(K x, I i, std::string &err)>> &props, std::string &error)
^
/home/dk/qib/src/qib.cpp:658:90: error: template argument 2 is invalid
V setProperties(K dict, std::map<std::string, std::function<V(K x, I i, std::string &err)>> &props, std::string &error)
^~
/home/dk/qib/src/qib.cpp:658:90: error: template argument 4 is invalid
/home/dk/qib/src/qib.cpp:658:30: error: ‘std::map’ is not a type
V setProperties(K dict, std::map<std::string, std::function<V(K x, I i, std::string &err)>> &props, std::string &error)
^~~
/home/dk/qib/src/qib.cpp:658:33: error: expected ‘,’ or ‘...’ before ‘<’ token
V setProperties(K dict, std::map<std::string, std::function<V(K x, I i, std::string &err)>> &props, std::string &error)
^
/home/dk/qib/src/qib.cpp: In function ‘V setProperties(K, int)’:
/home/dk/qib/src/qib.cpp:664:9: error: ‘error’ was not declared in this scope
error = "Keys must be syms";
^~~~~
/home/dk/qib/src/qib.cpp:664:9: note: suggested alternative: ‘perror’
error = "Keys must be syms";
^~~~~
perror
/home/dk/qib/src/qib.cpp:672:19: error: ‘props’ was not declared in this scope
auto it = props.find(key);
^~~~~
/home/dk/qib/src/qib.cpp:674:35: error: ‘error’ was not declared in this scope
(it->second)(vals, i, error);
^~~~~
/home/dk/qib/src/qib.cpp:674:35: note: suggested alternative: ‘perror’
(it->second)(vals, i, error);
^~~~~
perror
/home/dk/qib/src/qib.cpp:680:13: error: ‘error’ was not declared in this scope
error = stringFormat("Key not recognized: %s", key.c_str());
^~~~~
/home/dk/qib/src/qib.cpp:680:13: note: suggested alternative: ‘perror’
error = stringFormat("Key not recognized: %s", key.c_str());
^~~~~
perror
/home/dk/qib/src/qib.cpp: In function ‘Contract createContract(K, std::__cxx11::string&)’:
/home/dk/qib/src/qib.cpp:693:47: error: ‘function’ is not a member of ‘std’
auto map = new std::map<std::string, std::function<V(K, I, std::string&)>> {
^~~~~~~~
/home/dk/qib/src/qib.cpp:693:47: note: ‘std::function’ is defined in header ‘<functional>’; did you forget to ‘#include <functional>’?
/home/dk/qib/src/qib.cpp:693:47: error: ‘function’ is not a member of ‘std’
/home/dk/qib/src/qib.cpp:693:47: note: ‘std::function’ is defined in header ‘<functional>’; did you forget to ‘#include <functional>’?
/home/dk/qib/src/qib.cpp:693:76: error: expression list treated as compound expression in functional cast [-fpermissive]
auto map = new std::map<std::string, std::function<V(K, I, std::string&)>> {
^
/home/dk/qib/src/qib.cpp:693:76: error: template argument 2 is invalid
/home/dk/qib/src/qib.cpp:693:76: error: template argument 4 is invalid
/home/dk/qib/src/qib.cpp:693:80: error: expected primary-expression before ‘{’ token
auto map = new std::map<std::string, std::function<V(K, I, std::string&)>> {
^
/home/dk/qib/src/qib.cpp: In function ‘Order createOrder(K, std::__cxx11::string&)’:
/home/dk/qib/src/qib.cpp:717:47: error: ‘function’ is not a member of ‘std’
auto map = new std::map<std::string, std::function<V(K, I, std::string&)>> {
^~~~~~~~
/home/dk/qib/src/qib.cpp:717:47: note: ‘std::function’ is defined in header ‘<functional>’; did you forget to ‘#include <functional>’?
/home/dk/qib/src/qib.cpp:717:47: error: ‘function’ is not a member of ‘std’
/home/dk/qib/src/qib.cpp:717:47: note: ‘std::function’ is defined in header ‘<functional>’; did you forget to ‘#include <functional>’?
/home/dk/qib/src/qib.cpp:717:76: error: expression list treated as compound expression in functional cast [-fpermissive]
auto map = new std::map<std::string, std::function<V(K, I, std::string&)>> {
^
/home/dk/qib/src/qib.cpp:717:76: error: template argument 2 is invalid
/home/dk/qib/src/qib.cpp:717:76: error: template argument 4 is invalid
/home/dk/qib/src/qib.cpp:717:80: error: expected primary-expression before ‘{’ token
auto map = new std::map<std::string, std::function<V(K, I, std::string&)>> {
^
/home/dk/qib/src/qib.cpp: In function ‘ExecutionFilter createExecutionFilter(K, std::__cxx11::string&)’:
/home/dk/qib/src/qib.cpp:771:47: error: ‘function’ is not a member of ‘std’
auto map = new std::map<std::string, std::function<V(K, I, std::string&)>> {
^~~~~~~~
/home/dk/qib/src/qib.cpp:771:47: note: ‘std::function’ is defined in header ‘<functional>’; did you forget to ‘#include <functional>’?
/home/dk/qib/src/qib.cpp:771:47: error: ‘function’ is not a member of ‘std’
/home/dk/qib/src/qib.cpp:771:47: note: ‘std::function’ is defined in header ‘<functional>’; did you forget to ‘#include <functional>’?
/home/dk/qib/src/qib.cpp:771:76: error: expression list treated as compound expression in functional cast [-fpermissive]
auto map = new std::map<std::string, std::function<V(K, I, std::string&)>> {
^
/home/dk/qib/src/qib.cpp:771:76: error: template argument 2 is invalid
/home/dk/qib/src/qib.cpp:771:76: error: template argument 4 is invalid
/home/dk/qib/src/qib.cpp:771:80: error: expected primary-expression before ‘{’ token
auto map = new std::map<std::string, std::function<V(K, I, std::string&)>> {
^
/home/dk/qib/src/qib.cpp: In function ‘ScannerSubscription createScannerSubscription(K, std::__cxx11::string&)’:
/home/dk/qib/src/qib.cpp:788:47: error: ‘function’ is not a member of ‘std’
auto map = new std::map<std::string, std::function<V(K, I, std::string&)>> {
^~~~~~~~
/home/dk/qib/src/qib.cpp:788:47: note: ‘std::function’ is defined in header ‘<functional>’; did you forget to ‘#include <functional>’?
/home/dk/qib/src/qib.cpp:788:47: error: ‘function’ is not a member of ‘std’
/home/dk/qib/src/qib.cpp:788:47: note: ‘std::function’ is defined in header ‘<functional>’; did you forget to ‘#include <functional>’?
/home/dk/qib/src/qib.cpp:788:76: error: expression list treated as compound expression in functional cast [-fpermissive]
auto map = new std::map<std::string, std::function<V(K, I, std::string&)>> {
^
/home/dk/qib/src/qib.cpp:788:76: error: template argument 2 is invalid
/home/dk/qib/src/qib.cpp:788:76: error: template argument 4 is invalid
/home/dk/qib/src/qib.cpp:788:80: error: expected primary-expression before ‘{’ token
auto map = new std::map<std::string, std::function<V(K, I, std::string&)>> {
^
CMakeFiles/qib.0.0.1.dir/build.make:86: recipe for target 'CMakeFiles/qib.0.0.1.dir/src/qib.cpp.o' failed
make[2]: *** [CMakeFiles/qib.0.0.1.dir/src/qib.cpp.o] Error 1
CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/qib.0.0.1.dir/all' failed
make[1]: *** [CMakeFiles/qib.0.0.1.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2
```